### PR TITLE
[OBSPruningModifier] pathway to add default initialize args in modifier tests

### DIFF
--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_obs.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_obs.py
@@ -126,15 +126,14 @@ def _get_dataloader_builder(
     scope="function",
 )
 class TestOBSPruningModifier(ScheduledUpdateModifierTest):
-    def add_default_initialize_kwargs(self, initialize_kwargs) -> Dict[str, Any]:
+    def get_default_initialize_kwargs(self) -> Dict[str, Any]:
         # add default no-op grad_sampler for initialization on non lifecycle tests
-        if "grad_sampler" not in initialize_kwargs:
-            initialize_kwargs["grad_sampler"] = {
+        return {
+            "grad_sampler": {
                 "data_loader_builder": lambda *loader_args, **loader_kwargs: [],
                 "loss_function": lambda *loss_args, **loss_kwargs: None,
             }
-
-        return initialize_kwargs
+        }
 
     @pytest.mark.parametrize(
         "dataset_lambda, obs_batch_size",

--- a/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_obs.py
+++ b/tests/sparseml/pytorch/sparsification/pruning/test_modifier_pruning_obs.py
@@ -126,6 +126,16 @@ def _get_dataloader_builder(
     scope="function",
 )
 class TestOBSPruningModifier(ScheduledUpdateModifierTest):
+    def add_default_initialize_kwargs(self, initialize_kwargs) -> Dict[str, Any]:
+        # add default no-op grad_sampler for initialization on non lifecycle tests
+        if "grad_sampler" not in initialize_kwargs:
+            initialize_kwargs["grad_sampler"] = {
+                "data_loader_builder": lambda *loader_args, **loader_kwargs: [],
+                "loss_function": lambda *loss_args, **loss_kwargs: None,
+            }
+
+        return initialize_kwargs
+
     @pytest.mark.parametrize(
         "dataset_lambda, obs_batch_size",
         [(MLPDataset, 4)],

--- a/tests/sparseml/pytorch/sparsification/test_modifier.py
+++ b/tests/sparseml/pytorch/sparsification/test_modifier.py
@@ -61,10 +61,10 @@ __all__ = [
     reason="Skipping pytorch tests",
 )
 class ModifierTest(BaseModifierTest):
-    def add_default_initialize_kwargs(self, **kwargs) -> Dict[str, Any]:
+    def get_default_initialize_kwargs(self) -> Dict[str, Any]:
         # add defaults for any required kwargs for modifier initialization
         # that are not explicitly needed for every test
-        return kwargs
+        return {}
 
     # noinspection PyMethodOverriding
     def initialize_helper(
@@ -75,8 +75,10 @@ class ModifierTest(BaseModifierTest):
         log_initialize: bool = True,
         **kwargs,
     ):
-        kwargs = self.add_default_initialize_kwargs(kwargs)
-        modifier.initialize(model, epoch, **kwargs)
+        # override any default kwargs with given kwargs
+        initialize_kwargs = self.get_default_initialize_kwargs()
+        initialize_kwargs.update(kwargs)
+        modifier.initialize(model, epoch, **initialize_kwargs)
 
         if log_initialize:
             modifier.initialize_loggers(LoggerManager([PythonLogger()]))

--- a/tests/sparseml/pytorch/sparsification/test_modifier.py
+++ b/tests/sparseml/pytorch/sparsification/test_modifier.py
@@ -14,7 +14,7 @@
 
 import os
 import sys
-from typing import Callable
+from typing import Any, Callable, Dict
 
 import pytest
 from torch import Tensor
@@ -61,6 +61,11 @@ __all__ = [
     reason="Skipping pytorch tests",
 )
 class ModifierTest(BaseModifierTest):
+    def add_default_initialize_kwargs(self, **kwargs) -> Dict[str, Any]:
+        # add defaults for any required kwargs for modifier initialization
+        # that are not explicitly needed for every test
+        return kwargs
+
     # noinspection PyMethodOverriding
     def initialize_helper(
         self,
@@ -70,6 +75,7 @@ class ModifierTest(BaseModifierTest):
         log_initialize: bool = True,
         **kwargs,
     ):
+        kwargs = self.add_default_initialize_kwargs(kwargs)
         modifier.initialize(model, epoch, **kwargs)
 
         if log_initialize:


### PR DESCRIPTION
unblocks issue of having grad sampler required to initialize `OBSPruningModifier` in testing

**test_plan**
existing tests green with this patch